### PR TITLE
mppenc: framerate issue

### DIFF
--- a/gst/rockchipmpp/gstmpph264enc.c
+++ b/gst/rockchipmpp/gstmpph264enc.c
@@ -79,7 +79,7 @@ enum
 };
 
 #define GST_MPP_H264_ENC_SIZE_CAPS \
-    "width  = (int) [ 96, MAX ], height = (int) [ 64, MAX ]"
+    "width  = (int) [ 96, MAX ], height = (int) [ 64, MAX ], framerate = (fraction) [ 0/1, 2147483647/1 ]"
 
 static GstStaticPadTemplate gst_mpp_h264_enc_src_template =
 GST_STATIC_PAD_TEMPLATE ("src",

--- a/gst/rockchipmpp/gstmpph265enc.c
+++ b/gst/rockchipmpp/gstmpph265enc.c
@@ -62,7 +62,7 @@ enum
 };
 
 #define GST_MPP_H265_ENC_SIZE_CAPS \
-    "width  = (int) [ 96, MAX ], height = (int) [ 64, MAX ]"
+    "width  = (int) [ 96, MAX ], height = (int) [ 64, MAX ], framerate = (fraction) [ 0/1, 2147483647/1 ]"
 
 static GstStaticPadTemplate gst_mpp_h265_enc_src_template =
 GST_STATIC_PAD_TEMPLATE ("src",


### PR DESCRIPTION
When a conversion was enforced in mppenc, framerate information was lost which resulted in video being reported at the default 30fps no matter the delivered framerate. Caused problems in OBS/VLC